### PR TITLE
Visual overhaul: pinned chords, static lines, warm colors

### DIFF
--- a/src/components/ChordDegreeCell.tsx
+++ b/src/components/ChordDegreeCell.tsx
@@ -1,8 +1,10 @@
+import { useRef, type MouseEvent } from "react"
 import type { Extension, NoteRef } from "../lib/music"
 import { buildSlashChordVoicing, CHORD_CELL_SIDE, ROMAN_NUMERALS } from "../lib/music"
 import { notes } from "../lib/notes"
 import { playChord, arpeggiateChord } from "../lib/audio"
-import { degreeColor } from "../lib/theme"
+import { degreeColor, neonHoverCellOutline } from "../lib/theme"
+import { Pin } from "lucide-react"
 import NoteCell from "./NoteCell"
 import ExtensionPanel from "./ExtensionPanel"
 import { Popover, PopoverTrigger, Pill } from "./ui"
@@ -10,7 +12,6 @@ import { Popover, PopoverTrigger, Pill } from "./ui"
 import type { RowId } from "../lib/geometry"
 
 const DATA_ROW: RowId = "diatonic-row"
-const HOVER_COLOR = "#000000"
 
 export type ChordDegreeCellProps = {
   chordNumeralIdx: number,
@@ -23,6 +24,7 @@ export type ChordDegreeCellProps = {
   modeNotes: NoteRef[],
   arpeggiate: boolean,
   hoveredIndex: number | null,
+  pinnedChordIndex: number | null,
   isPopoverOpen: boolean,
   onPopoverOpenChange: (open: boolean) => void,
   selectedExtensions: Extension[],
@@ -30,6 +32,8 @@ export type ChordDegreeCellProps = {
   onSlashBassChange?: (degreeIdx: number, bassDegree: number | null) => void,
   onHover: (idx: number, original: NoteRef[], modified: NoteRef[]) => void,
   onHoverClear: () => void,
+  isPinned: boolean,
+  onPinnedChordChange: (index: number | null) => void,
 }
 
 export default function ChordDegreeCell({
@@ -43,6 +47,7 @@ export default function ChordDegreeCell({
   modeNotes,
   arpeggiate,
   hoveredIndex,
+  pinnedChordIndex,
   isPopoverOpen,
   onPopoverOpenChange,
   selectedExtensions,
@@ -50,11 +55,36 @@ export default function ChordDegreeCell({
   onSlashBassChange,
   onHover,
   onHoverClear,
+  isPinned,
+  onPinnedChordChange,
 }: ChordDegreeCellProps) {
-  const degreeBg = degreeColor(chordNumeralIdx)
+  const cellGroupRef = useRef<HTMLDivElement>(null)
+
+  const handlePinClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    e.preventDefault()
+    if (isPinned) {
+      onPinnedChordChange(null)
+      onHoverClear()
+      requestAnimationFrame(() => {
+        if (cellGroupRef.current?.matches(":hover")) {
+          onHover(chordNumeralIdx, originalNotes, chordNotesArr)
+        }
+      })
+    } else {
+      onPinnedChordChange(chordNumeralIdx)
+      onHover(chordNumeralIdx, originalNotes, chordNotesArr)
+    }
+  }
+
+  const isHoverOrPinBorder =
+    hoveredIndex === chordNumeralIdx || pinnedChordIndex === chordNumeralIdx
+
+  const degreeBg = isHoverOrPinBorder ? degreeColor(chordNumeralIdx) : null
 
   return (
     <div
+      ref={cellGroupRef}
       className="relative group"
       style={{
         width: `${CHORD_CELL_SIDE}px`,
@@ -74,9 +104,7 @@ export default function ChordDegreeCell({
         style={{
           width: `${CHORD_CELL_SIDE}px`,
           height: `${CHORD_CELL_SIDE}px`,
-          ...(hoveredIndex === chordNumeralIdx
-            ? { border: `2px solid ${HOVER_COLOR}` }
-            : {}),
+          ...(isHoverOrPinBorder ? { ...neonHoverCellOutline } : {}),
         }}
         onMouseEnter={() => onHover(chordNumeralIdx, originalNotes, chordNotesArr)}
         onMouseLeave={() => onHoverClear()}
@@ -119,9 +147,9 @@ export default function ChordDegreeCell({
 
       </NoteCell>
 
-      {/* Extensions button — below the cell */}
+      {/* Pin + Extensions — below the cell */}
       <div
-        className="absolute -bottom-7 inset-x-0 flex justify-center z-10"
+        className="absolute -bottom-7 inset-x-0 z-10 flex justify-center items-center gap-1"
         onClick={(e) => e.stopPropagation()}
         onMouseEnter={(e) => {
           if (isPopoverOpen) return
@@ -134,6 +162,19 @@ export default function ChordDegreeCell({
           onHoverClear()
         }}
       >
+        <button
+          type="button"
+          className={
+            isPinned
+              ? "inline-flex h-6 min-w-[2.25rem] shrink-0 items-center justify-center rounded-full border border-[var(--app-border)] bg-[var(--app-primaryFill)] px-2 text-[10px] font-medium text-[var(--app-primary)]"
+              : "inline-flex h-6 min-w-[2.25rem] shrink-0 items-center justify-center rounded-full border border-[var(--app-border)] bg-white px-2 text-[10px] font-medium text-black hover:bg-black/[0.08]"
+          }
+          aria-label={isPinned ? "Unpin chord" : "Pin chord"}
+          aria-pressed={isPinned}
+          onClick={handlePinClick}
+        >
+          <Pin className="h-3 w-3" strokeWidth={2} />
+        </button>
         <Popover
           open={isPopoverOpen}
           onOpenChange={onPopoverOpenChange}

--- a/src/components/ChordMajorScaleRow.tsx
+++ b/src/components/ChordMajorScaleRow.tsx
@@ -3,7 +3,7 @@ import { FLAT, IONIAN, SQUARE_SIDE, spellNoteSequence, spellNote } from "../lib/
 import { notes } from "../lib/notes"
 import { renderNote } from "./NoteLabel"
 import Strikethrough from "./Strikethrough"
-import { scaleToneBand, MUTED_TEXT } from "../lib/theme"
+import { BLACK, neonHoverCellOutline, scaleToneBand, MUTED_TEXT } from "../lib/theme"
 import NoteCell from "./NoteCell"
 import NotesArray from "./NotesArray"
 
@@ -171,6 +171,7 @@ export default function ChordMajorScaleRow({ chordNotes, chordRootIndex }: Chord
       caption={caption}
       captionSubtitle={isEmpty ? "Notes in the selected chord in its major scale" : undefined}
       clipContent={false}
+      rowStrokeColor={BLACK}
     >
       {majorScale.map((_, idx) => {
           const degreeIdx = minDegreeIdx + idx
@@ -206,6 +207,7 @@ export default function ChordMajorScaleRow({ chordNotes, chordRootIndex }: Chord
                 className="text-black font-semibold"
                 optBackground={chordToneBg(degreeIdx)}
                 optCaption={info.degreeLabel}
+                style={neonHoverCellOutline}
               >
                 {scaleNote && renderNote(scaleNote)}
               </NoteCell>
@@ -223,7 +225,7 @@ export default function ChordMajorScaleRow({ chordNotes, chordRootIndex }: Chord
           )
           const sep = <span className={`text-[9px] ${MUTED_TEXT}`}>{arrow}</span>
           return (
-            <NoteCell key={idx} idx={idx} optBackground={chordToneBg(degreeIdx)} optCaption={info.degreeLabel}>
+            <NoteCell key={idx} idx={idx} optBackground={chordToneBg(degreeIdx)} optCaption={info.degreeLabel} style={neonHoverCellOutline}>
               <div className="flex items-center gap-[2px] leading-none">
                 {info.isFlat ? <>{actual}{sep}{natural}</> : <>{natural}{sep}{actual}</>}
               </div>

--- a/src/components/ChromaticScaleRow.tsx
+++ b/src/components/ChromaticScaleRow.tsx
@@ -3,19 +3,18 @@ import type { Note } from "../models"
 import { CHROMATIC_SCALE } from "../lib/notes"
 import { renderNote } from "./NoteLabel"
 import { BASE_SCALE_LEFT_OVERFLOW, BASE_SCALE_WITH_OVERFLOW_SIZE, SQUARE_SIDE } from "../lib/music"
-import { colors, scaleToneBand } from "../lib/theme"
+import { BLACK, colors, neonHoverCellOutline } from "../lib/theme"
 import NotesArray from "./NotesArray"
 import NoteCell from "./NoteCell"
 
-const HIGHLIGHTED_BASE_STYLE = (color: string) => ({
-  border: `2px solid ${color}`,
-})
+const HIGHLIGHTED_CHROMATIC_STYLE = neonHoverCellOutline
 
 export type ChromaticScaleRowProps = {
   sliderRef: (node: HTMLDivElement) => void,
   notes: Note[],
   modeIntervals: Interval[],
   highlightedBaseIdxs: Set<number>,
+  highlightedBaseBackgrounds: Map<number, string> | null,
   onPlayNote: (note: Note) => void,
   onPrev: () => void,
   onNext: () => void,
@@ -26,6 +25,7 @@ export default function ChromaticScaleRow({
   notes,
   modeIntervals,
   highlightedBaseIdxs,
+  highlightedBaseBackgrounds,
   onPlayNote,
   onPrev,
   onNext,
@@ -36,6 +36,7 @@ export default function ChromaticScaleRow({
       cellWidth={SQUARE_SIDE}
       clipContent
       zIndex={1}
+      rowStrokeColor={BLACK}
       caption="Chromatic Scale"
       captionSubtitle="All notes in sequential order"
     >
@@ -46,25 +47,25 @@ export default function ChromaticScaleRow({
         }}
       >
         {(() => {
-          const scaleIdxs = CHROMATIC_SCALE.map((_, i) => i).filter(
-            (i) => i > 0 && modeIntervals.includes(i),
-          )
-          const scaleBand = scaleToneBand(scaleIdxs.length)
-          const scaleBandMap = new Map(scaleIdxs.map((si, bi) => [si, scaleBand[bi]!]))
-
           return CHROMATIC_SCALE.map((_, idx) => {
             let background: string | null = null
             if (idx === 0) {
-              background = colors.rootFill
-            } else {
-              background = scaleBandMap.get(idx) ?? null
+              background = colors.mutedDark
+            } else if (modeIntervals.includes(idx)) {
+              background = colors.border
             }
+            const isInMode = modeIntervals.includes(idx)
             return (
               <NoteCell
                 key={idx}
                 dataRow="chromatic-row"
                 dataIdx={idx}
                 optBackground={background}
+                style={
+                  isInMode
+                    ? { boxShadow: `inset 0 0 0 1px ${BLACK}, 0 0 0 1px ${BLACK}` }
+                    : undefined
+                }
               />
             )
           })
@@ -82,10 +83,15 @@ export default function ChromaticScaleRow({
             dataRow="base-row"
             dataIdx={idx}
             className="keen-slider__slide cursor-pointer"
+            optBackground={
+              highlightedBaseIdxs.has(idx)
+                ? (highlightedBaseBackgrounds?.get(idx) ?? null)
+                : null
+            }
             style={
               highlightedBaseIdxs.has(idx)
-                ? HIGHLIGHTED_BASE_STYLE("#000000")
-                : { border: "2px solid transparent" }
+                ? HIGHLIGHTED_CHROMATIC_STYLE
+                : undefined
             }
             onClick={() => onPlayNote(note)}
           >

--- a/src/components/ControlsBar.tsx
+++ b/src/components/ControlsBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import type { Note } from "../models"
 import { renderNote } from "./NoteLabel"
 import { MODES, Mode } from "../lib/music"
@@ -25,6 +25,12 @@ export default function ControlsBar({
   onArpeggiateToggle,
 }: ControlsBarProps) {
   const [showKeyHint, setShowKeyHint] = useState(false)
+  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const showHint = useCallback(() => {
+    if (hintTimer.current) clearTimeout(hintTimer.current)
+    setShowKeyHint(true)
+    hintTimer.current = setTimeout(() => setShowKeyHint(false), 1500)
+  }, [])
 
   return (
     <>
@@ -33,10 +39,7 @@ export default function ControlsBar({
           <span className="text-xs font-medium uppercase tracking-wider text-black">Key</span>
           <div
             className="relative cursor-pointer"
-            onClick={() => {
-              setShowKeyHint(true)
-              setTimeout(() => setShowKeyHint(false), 2500)
-            }}
+            onClick={showHint}
           >
             <Tag>{renderNote(rootNote)}</Tag>
             {showKeyHint && (
@@ -58,17 +61,20 @@ export default function ControlsBar({
           />
         </div>
         <button
-          className="flex items-center gap-2 cursor-pointer"
+          type="button"
+          className="flex cursor-pointer items-center gap-2"
           onClick={onArpeggiateToggle}
+          aria-pressed={arpeggiate}
+          aria-label="Arpeggiate chord playback"
         >
           <span className="text-xs font-medium uppercase tracking-wider text-black">Arpeggiate</span>
           <div
-            className={`relative h-5 w-9 rounded-full ${
+            className={`relative h-5 w-9 rounded-full transition-colors duration-200 ease-out ${
               arpeggiate ? "bg-[var(--app-primary)]" : "bg-[var(--app-border)]"
             }`}
           >
             <div
-              className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm ${
+              className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 ease-[cubic-bezier(0.4,0,0.2,1)] ${
                 arpeggiate ? "translate-x-[18px]" : "translate-x-0.5"
               }`}
             />

--- a/src/components/DiatonicScaleDegreesRow.tsx
+++ b/src/components/DiatonicScaleDegreesRow.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react"
 import type { Extension, NoteRef } from "../lib/music"
 import { getChordDescriptor, getChordNotes, applyExtensions, toNoteRefs, CHORD_CELL_SIDE, ROMAN_NUMERALS } from "../lib/music"
 import { notes } from "../lib/notes"
+import { BLACK } from "../lib/theme"
 import NotesArray from "./NotesArray"
 import ChordDegreeCell from "./ChordDegreeCell"
 
@@ -22,6 +23,8 @@ export type DiatonicScaleDegreesRowProps = {
   captionRight?: React.ReactNode,
   arpeggiate: boolean,
   hoveredIndex: number | null,
+  pinnedChordIndex: number | null,
+  onPinnedChordChange: (index: number | null) => void,
 }
 
 const CAPTION = "Diatonic Chords"
@@ -39,6 +42,8 @@ export default function DiatonicScaleDegreesRow({
   captionRight,
   arpeggiate,
   hoveredIndex,
+  pinnedChordIndex,
+  onPinnedChordChange,
 }: DiatonicScaleDegreesRowProps) {
   const degreeCount = modeLength > 0 ? modeLength : ROMAN_NUMERALS.length + 1
   const chordNumerals = Array.from({ length: degreeCount }, (_, idx) =>
@@ -88,6 +93,7 @@ export default function DiatonicScaleDegreesRow({
       captionSubtitle={CAPTION_SUBTITLE}
       captionRight={captionRight}
       clipContent={false}
+      rowStrokeColor={BLACK}
       zIndex={openIdx !== null ? 4 : undefined}
     >
       {chordNumerals.map((chordNumeral, chordNumeralIdx) => {
@@ -106,6 +112,7 @@ export default function DiatonicScaleDegreesRow({
             modeNotes={visibleModeNotes}
             arpeggiate={arpeggiate}
             hoveredIndex={hoveredIndex}
+            pinnedChordIndex={pinnedChordIndex}
             isPopoverOpen={openIdx === chordNumeralIdx}
             onPopoverOpenChange={(open) => setOpenIdx(open ? chordNumeralIdx : null)}
             selectedExtensions={selectedExtensions[chordNumeralIdx] ?? []}
@@ -113,6 +120,8 @@ export default function DiatonicScaleDegreesRow({
             onSlashBassChange={onSlashBassChange}
             onHover={emitHover}
             onHoverClear={clearHover}
+            isPinned={pinnedChordIndex === chordNumeralIdx}
+            onPinnedChordChange={onPinnedChordChange}
           />
         )
       })}

--- a/src/components/FixedLines.tsx
+++ b/src/components/FixedLines.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react"
 import type { CellLink } from "../lib/geometry"
 import { StaticConnection } from "../models"
 import { bezierPath } from "../lib/bezier"
-import { colors } from "../lib/theme"
+import { BLACK } from "../lib/theme"
 import { useContainerMeasure } from "../hooks"
 
 export type FixedLinesProps = {
@@ -23,20 +23,34 @@ export default function FixedLines({ containerRef, connections }: FixedLinesProp
     const scrollLeft = container.scrollLeft
     const scrollTop = container.scrollTop
 
+    // Measure the root chromatic cell (index 0) to extrapolate overflow positions.
+    const rootEl = container.querySelector(`[data-row="chromatic-row"][data-idx="0"]`)
+    const rootRect = rootEl?.getBoundingClientRect() ?? null
+    const cellWidth = rootRect?.width ?? 0
+
     const nextLines = connections
       .map(({ fromRow, fromIdx, toRow, toIdx }) => {
-        const fromEl = container.querySelector(`[data-row="${fromRow}"][data-idx="${fromIdx}"]`)
         const toEl = container.querySelector(`[data-row="${toRow}"][data-idx="${toIdx}"]`)
-        if (!fromEl || !toEl) return null
+        if (!toEl) return null
 
-        const fromRect = fromEl.getBoundingClientRect()
+        const fromEl = container.querySelector(`[data-row="${fromRow}"][data-idx="${fromIdx}"]`)
+        let fromX: number
+        let fromY: number
+        if (fromEl) {
+          const fromRect = fromEl.getBoundingClientRect()
+          fromX = fromRect.left - containerRect.left + fromRect.width / 2 + scrollLeft
+          fromY = fromRect.bottom - containerRect.top + scrollTop
+        } else if (rootRect) {
+          fromX = rootRect.left - containerRect.left + rootRect.width / 2 + fromIdx * cellWidth + scrollLeft
+          fromY = rootRect.bottom - containerRect.top + scrollTop
+        } else {
+          return null
+        }
+
         const toRect = toEl.getBoundingClientRect()
 
         return new StaticConnection(
-          {
-            x: fromRect.left - containerRect.left + fromRect.width / 2 + scrollLeft,
-            y: fromRect.bottom - containerRect.top + scrollTop,
-          },
+          { x: fromX, y: fromY },
           {
             x: toRect.left - containerRect.left + toRect.width / 2 + scrollLeft,
             y: toRect.top - containerRect.top + scrollTop,
@@ -69,8 +83,8 @@ export default function FixedLines({ containerRef, connections }: FixedLinesProp
         <path
           key={idx}
           d={bezierPath(conn.from, conn.to)}
-          stroke={colors.border}
-          strokeWidth="1.5"
+          stroke="darkgray"
+          strokeWidth="2"
           fill="none"
         />
       ))}

--- a/src/components/HoverLines.tsx
+++ b/src/components/HoverLines.tsx
@@ -1,75 +1,71 @@
 import { useCallback, useMemo, useState } from "react"
-import type { ModeDataProps, NoteIndex, NoteRef } from "../lib/music"
+import type { NoteIndex, NoteRef } from "../lib/music"
 import type { ChordHighlightPair } from "../lib/geometry"
-import { Connection, IntervalConnection, RemovedConnection, AddedConnection, BassConnection } from "../models"
-import { bezierPath, bezierPointAt } from "../lib/bezier"
 import { buildHoverConnections } from "../lib/hoverConnections"
+import { bezierPath, bezierPointAt } from "../lib/bezier"
+import { Connection, IntervalConnection, RemovedConnection, AddedConnection, BassConnection } from "../models"
 import { getIntervalLabel } from "../lib/music"
+import { BLACK } from "../lib/theme"
 import { useContainerMeasure } from "../hooks"
 import IntervalLabel from "./IntervalLabel"
+import type { ModeDataProps } from "../lib/music"
 
-export type HoverLinesProps = ModeDataProps & {
-  containerRef: React.RefObject<HTMLDivElement | null>,
-  hoveredIndex: number | null,
+export type HoverLinesLayer = {
+  hoveredIndex: number,
   chordHighlightPairs: ChordHighlightPair[],
   originalChordNotes: NoteRef[],
   modifiedChordNotes: NoteRef[],
   slashBassNoteIndex: NoteIndex | null,
 }
 
+export type HoverLinesProps = ModeDataProps & {
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  layers: HoverLinesLayer[],
+  freeze: boolean,
+}
+
 export default function HoverLines({
   containerRef,
-  hoveredIndex,
+  layers,
+  freeze,
   modeNotesWithOverflow,
   modeLeftOverflowSize,
-  chordHighlightPairs,
-  originalChordNotes,
-  modifiedChordNotes,
-  slashBassNoteIndex,
 }: HoverLinesProps) {
-  const [lines, setLines] = useState<Connection[]>([])
+  const [lines, setLines] = useState<{ layerIdx: number, conn: Connection }[]>([])
 
   const modeIndices = useMemo(
     () => modeNotesWithOverflow.map((r) => r.index),
     [modeNotesWithOverflow],
   )
-  const originalIndices = useMemo(
-    () => originalChordNotes.map((r) => r.index),
-    [originalChordNotes],
-  )
-  const modifiedIndices = useMemo(
-    () => modifiedChordNotes.map((r) => r.index),
-    [modifiedChordNotes],
-  )
 
   const measure = useCallback(() => {
+    if (freeze) return
     const container = containerRef?.current
-    if (!container || hoveredIndex === null) {
+    if (!container || layers.length === 0) {
       setLines([])
       return
     }
-    setLines(
-      buildHoverConnections({
+    const built: { layerIdx: number, conn: Connection }[] = []
+    for (let layerIdx = 0; layerIdx < layers.length; layerIdx++) {
+      const layer = layers[layerIdx]!
+      const originalIndices = layer.originalChordNotes.map((r) => r.index)
+      const modifiedIndices = layer.modifiedChordNotes.map((r) => r.index)
+      const conns = buildHoverConnections({
         container,
-        hoveredIndex,
+        hoveredIndex: layer.hoveredIndex,
         modeNotesWithOverflow: modeIndices,
         modeLeftOverflowSize,
-        chordHighlightPairs,
+        chordHighlightPairs: layer.chordHighlightPairs,
         originalChordNotes: originalIndices,
         modifiedChordNotes: modifiedIndices,
-        slashBassNoteIndex,
-      }),
-    )
-  }, [
-    containerRef,
-    hoveredIndex,
-    modeIndices,
-    modeLeftOverflowSize,
-    chordHighlightPairs,
-    originalIndices,
-    modifiedIndices,
-    slashBassNoteIndex,
-  ])
+        slashBassNoteIndex: layer.slashBassNoteIndex,
+      })
+      for (const conn of conns) {
+        built.push({ layerIdx, conn })
+      }
+    }
+    setLines(built)
+  }, [containerRef, freeze, layers, modeIndices, modeLeftOverflowSize])
 
   useContainerMeasure(containerRef, measure)
 
@@ -87,29 +83,27 @@ export default function HoverLines({
         zIndex: 3,
       }}
     >
-      {/* Render all paths first */}
-      {lines.map((conn, idx) => {
+      {lines.map(({ layerIdx, conn }, idx) => {
         const isRemoved = conn instanceof RemovedConnection
         return (
           <path
-            key={`p${idx}`}
+            key={`p-${layerIdx}-${idx}`}
             d={bezierPath(conn.from, conn.to)}
-            stroke="#000000"
-            strokeWidth="1.5"
+            stroke={BLACK}
+            strokeWidth="2"
             strokeLinecap="round"
             strokeDasharray={isRemoved ? "4 3" : undefined}
             fill="none"
           />
         )
       })}
-      {/* Render all labels on top */}
-      {lines.map((conn, idx) => {
+      {lines.map(({ layerIdx, conn }, idx) => {
         if (!(conn instanceof IntervalConnection)) return null
         if (conn instanceof RemovedConnection) return null
         const t = conn instanceof AddedConnection || conn instanceof BassConnection ? 0.85 : 0.5
         const labelPos = bezierPointAt(conn.from, conn.to, t)
         return (
-          <IntervalLabel key={`l${idx}`} x={labelPos.x} y={labelPos.y}>
+          <IntervalLabel key={`l-${layerIdx}-${idx}`} x={labelPos.x} y={labelPos.y}>
             {getIntervalLabel(conn.intervalSemitones)}
           </IntervalLabel>
         )

--- a/src/components/ModeNoteCell.tsx
+++ b/src/components/ModeNoteCell.tsx
@@ -3,7 +3,7 @@ import type { Note } from "../models"
 import { renderNote } from "./NoteLabel"
 import Strikethrough from "./Strikethrough"
 import NoteCell from "./NoteCell"
-import { MUTED_TEXT } from "../lib/theme"
+import { MUTED_TEXT, neonHoverCellOutline } from "../lib/theme"
 
 export type ModeNoteCellProps = {
   idx: number,
@@ -12,10 +12,11 @@ export type ModeNoteCellProps = {
   newValue: Note,
   onPlay: (note: Note) => void,
   isHighlighted: boolean,
+  highlightBackground: string | null,
   optCaption?: string | number | null,
 }
 
-const HIGHLIGHT_COLOR = "#000000"
+const HIGHLIGHT_STYLE = neonHoverCellOutline
 
 const ModeNoteCell = React.memo(function ModeNoteCell({
   idx,
@@ -24,6 +25,7 @@ const ModeNoteCell = React.memo(function ModeNoteCell({
   newValue,
   onPlay,
   isHighlighted,
+  highlightBackground,
   optCaption,
 }: ModeNoteCellProps) {
   const noteLabel = useMemo(
@@ -52,14 +54,13 @@ const ModeNoteCell = React.memo(function ModeNoteCell({
       dataIdx={dataIdx}
       onClick={handleClick}
       className="cursor-pointer"
+      optBackground={isHighlighted ? highlightBackground : null}
       optCaption={optCaption}
       style={
         isHighlighted
-          ? {
-              border: `2px solid ${HIGHLIGHT_COLOR}`,
-            }
+          ? HIGHLIGHT_STYLE
           : {
-              border: "2px solid transparent",
+              border: "none",
             }
       }
     >

--- a/src/components/ModeScaleRow.tsx
+++ b/src/components/ModeScaleRow.tsx
@@ -1,7 +1,7 @@
 import type { Interval, NoteInMode } from "../lib/music"
 import { SQUARE_SIDE } from "../lib/music"
 import type { Note } from "../models"
-import { colors } from "../lib/theme"
+import { BLACK } from "../lib/theme"
 import NotesArray from "./NotesArray"
 import NoteCell from "./NoteCell"
 import ModeNoteCell from "./ModeNoteCell"
@@ -12,6 +12,7 @@ export type ModeScaleRowProps = {
   modeIntervals: Interval[],
   modeLeftOverflowSize: number,
   highlightedModeIdxs: Set<number>,
+  highlightedModeBackgrounds: Map<number, string> | null,
   onPlayNote: (note: Note) => void,
 }
 
@@ -21,6 +22,7 @@ export default function ModeScaleRow({
   modeIntervals,
   modeLeftOverflowSize,
   highlightedModeIdxs,
+  highlightedModeBackgrounds,
   onPlayNote,
 }: ModeScaleRowProps) {
   return (
@@ -29,7 +31,8 @@ export default function ModeScaleRow({
       cellWidth={SQUARE_SIDE}
       clipContent
       zIndex={2}
-      rowBackground={colors.rowBg}
+      rowBackground="white"
+      rowStrokeColor={BLACK}
       caption={`${selectedModeName} Scale`}
       captionSubtitle="Notes that fall within the selected mode"
     >
@@ -59,6 +62,7 @@ export default function ModeScaleRow({
             newValue={noteInMode.spelled}
             onPlay={onPlayNote}
             isHighlighted={isHighlighted}
+            highlightBackground={highlightedModeBackgrounds?.get(noteInMode.index) ?? null}
             optCaption={scaleDegreeCaption}
           />
         )

--- a/src/components/NoteCell.tsx
+++ b/src/components/NoteCell.tsx
@@ -1,6 +1,7 @@
 import { cn } from "../lib/cn"
 import { SQUARE_SIDE } from "../lib/music"
 import type { RowId } from "../lib/geometry"
+import { BLACK } from "../lib/theme"
 
 export type NoteCellProps = {
   idx?: number,
@@ -34,9 +35,10 @@ export default function NoteCell({
         width: `${SQUARE_SIDE}px`,
         height: `${SQUARE_SIDE}px`,
         background: optBackground || undefined,
-        borderRadius: "6px",
+        borderRadius: 0,
         fontFamily: "'JetBrains Mono', monospace",
-        border: optBackground ? "2px solid rgba(0,0,0,0.12)" : "2px solid transparent",
+        border: "none",
+        boxShadow: `inset 0 0 0 0.125px ${BLACK}, 0 0 0 0.125px ${BLACK}`,
         ...(customStyle ?? {}),
       }}
       {...props}

--- a/src/components/NotesArray.tsx
+++ b/src/components/NotesArray.tsx
@@ -1,5 +1,3 @@
-import { colors } from "../lib/theme"
-
 export type NotesArrayProps = {
   size: number,
   cellWidth: number,
@@ -10,6 +8,7 @@ export type NotesArrayProps = {
   clipContent: boolean,
   zIndex?: number,
   rowBackground?: string,
+  rowStrokeColor?: string,
 }
 
 export default function NotesArray({
@@ -22,6 +21,7 @@ export default function NotesArray({
   clipContent,
   zIndex,
   rowBackground,
+  rowStrokeColor,
 }: NotesArrayProps) {
   return (
     <div
@@ -61,12 +61,16 @@ export default function NotesArray({
           width: `${cellWidth * size}px`,
           height: `${cellWidth}px`,
           position: "relative",
-          boxSizing: "content-box",
-          background: rowBackground ?? colors.rowBg,
-          border: "2px solid transparent",
+          boxSizing: "border-box",
+          background: rowBackground ?? "transparent",
+          border: "none",
+          borderRadius: 0,
+          boxShadow:
+            rowStrokeColor === undefined
+              ? undefined
+              : `0 0 0 2px ${rowStrokeColor}`,
           display: "flex",
           alignItems: "center",
-          borderRadius: "8px",
           overflow: clipContent ? "hidden" : undefined,
         }}
       >

--- a/src/components/VisualizerPanel.tsx
+++ b/src/components/VisualizerPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useKeenSlider } from "keen-slider/react"
 import "keen-slider/keen-slider.min.css"
 import type { Interval } from "../lib/music"
@@ -6,10 +6,16 @@ import { Note } from "../models"
 import {
   NATURAL, MODES, Mode,
   BASE_SCALE_LEFT_OVERFLOW, BASE_SCALE_WITH_OVERFLOW_SIZE,
+  getChordNotes,
+  applyExtensions,
+  toNoteRefs,
+  ROMAN_NUMERALS,
 } from "../lib/music"
 import { notes } from "../lib/notes"
 import { playNote } from "../lib/audio"
-import { useModeTones, useChordExtensions, useChordHover } from "../hooks"
+import { useModeTones, useChordExtensions, useChordHover, computeChordHoverLayer } from "../hooks"
+import type { HoverLinesLayer } from "./HoverLines"
+import { scaleToneBand } from "../lib/theme"
 
 import ControlsBar from "./ControlsBar"
 import FixedLines from "./FixedLines"
@@ -25,6 +31,11 @@ export default function VisualizerPanel() {
   const [selectedMode, setSelectedMode] = useState<Mode>(MODES[0]!)
   const [rootNote, setRootNote] = useState<Note>(DEFAULT_ROOT_NOTE)
   const [arpeggiate, setArpeggiate] = useState(false)
+  const [pinnedChordIndex, setPinnedChordIndex] = useState<number | null>(null)
+
+  useEffect(() => {
+    setPinnedChordIndex(null)
+  }, [selectedMode])
 
   const modeIntervals = useMemo((): Interval[] => selectedMode.intervals, [selectedMode])
 
@@ -54,7 +65,172 @@ export default function VisualizerPanel() {
     handleChordHoverChange,
   } = useChordHover(modeNotesWithOverflow, visibleModeNotes, slashBasses, notes)
 
+  const degreeCount =
+    modeIntervals.length > 0 ? modeIntervals.length : ROMAN_NUMERALS.length + 1
+  const chordNumerals = useMemo(
+    () =>
+      Array.from({ length: degreeCount }, (_, idx) =>
+        idx === degreeCount - 1 ? "I" : (ROMAN_NUMERALS[idx] ?? "I"),
+      ),
+    [degreeCount],
+  )
+
+  const chordRefsByDegree = useMemo(() => {
+    const modeIndices = visibleModeNotes.map((r) => r.index)
+    return chordNumerals.map((_, chordNumeralIdx) => {
+      const originalIndices = getChordNotes(modeIndices, chordNumeralIdx, "triads")
+      const activeExtensions = selectedExtensions[chordNumeralIdx] ?? []
+      const chordIndices = applyExtensions(originalIndices, activeExtensions)
+      const slashBass = slashBasses[chordNumeralIdx] ?? null
+      const originalNotes = toNoteRefs(originalIndices, notes)
+      const chordNotesArr = toNoteRefs(chordIndices, notes)
+      return { originalNotes, chordNotesArr, slashBass }
+    })
+  }, [chordNumerals, visibleModeNotes, selectedExtensions, slashBasses])
+
+  const pinnedChordLayer = useMemo(() => {
+    if (pinnedChordIndex === null) return null
+    const row = chordRefsByDegree[pinnedChordIndex]
+    if (!row) return null
+    return computeChordHoverLayer(
+      pinnedChordIndex,
+      row.originalNotes,
+      row.chordNotesArr,
+      modeNotesWithOverflow,
+      visibleModeNotes,
+      slashBasses,
+      notes,
+    )
+  }, [
+    pinnedChordIndex,
+    chordRefsByDegree,
+    modeNotesWithOverflow,
+    visibleModeNotes,
+    slashBasses,
+  ])
+
+  const mergedHighlightedBaseIdxs = useMemo(() => {
+    const s = new Set(highlightedBaseIdxs)
+    if (pinnedChordLayer) {
+      pinnedChordLayer.highlightedBaseIdxs.forEach((i) => {
+        s.add(i)
+      })
+    }
+    return s
+  }, [highlightedBaseIdxs, pinnedChordLayer])
+
+  const mergedHighlightedModeIdxs = useMemo(() => {
+    const s = new Set(highlightedModeIdxs)
+    if (pinnedChordLayer) {
+      pinnedChordLayer.highlightedModeIdxs.forEach((i) => {
+        s.add(i)
+      })
+    }
+    return s
+  }, [highlightedModeIdxs, pinnedChordLayer])
+
+  const hoverLineLayers = useMemo((): HoverLinesLayer[] => {
+    const out: HoverLinesLayer[] = []
+    const mIdx = hoveredTriadIndex
+    const pIdx = pinnedChordIndex
+    if (
+      pIdx !== null &&
+      pinnedChordLayer !== null &&
+      mIdx !== pIdx &&
+      pinnedChordLayer.voicedModified.length > 0
+    ) {
+      out.push({
+        hoveredIndex: pIdx,
+        chordHighlightPairs: pinnedChordLayer.chordHighlightPairs,
+        originalChordNotes: pinnedChordLayer.voicedOriginal,
+        modifiedChordNotes: pinnedChordLayer.voicedModified,
+        slashBassNoteIndex: pinnedChordLayer.slashBassNoteIndex,
+      })
+    }
+    if (mIdx !== null && voicedModified.length > 0) {
+      out.push({
+        hoveredIndex: mIdx,
+        chordHighlightPairs,
+        originalChordNotes: voicedOriginal,
+        modifiedChordNotes: voicedModified,
+        slashBassNoteIndex,
+      })
+    } else if (
+      pIdx !== null &&
+      pinnedChordLayer !== null &&
+      pinnedChordLayer.voicedModified.length > 0
+    ) {
+      out.push({
+        hoveredIndex: pIdx,
+        chordHighlightPairs: pinnedChordLayer.chordHighlightPairs,
+        originalChordNotes: pinnedChordLayer.voicedOriginal,
+        modifiedChordNotes: pinnedChordLayer.voicedModified,
+        slashBassNoteIndex: pinnedChordLayer.slashBassNoteIndex,
+      })
+    }
+    return out
+  }, [
+    hoveredTriadIndex,
+    pinnedChordIndex,
+    pinnedChordLayer,
+    chordHighlightPairs,
+    voicedOriginal,
+    voicedModified,
+    slashBassNoteIndex,
+  ])
+
+  const majorScaleChordNotes = useMemo(
+    () =>
+      hoveredTriadIndex !== null
+        ? fullVoicedModified
+        : (pinnedChordLayer?.fullVoicedModified ?? []),
+    [hoveredTriadIndex, fullVoicedModified, pinnedChordLayer],
+  )
+  const majorScaleChordRoot = useMemo(
+    () =>
+      hoveredTriadIndex !== null ? chordRootIndex : (pinnedChordLayer?.chordRootIndex ?? null),
+    [hoveredTriadIndex, chordRootIndex, pinnedChordLayer],
+  )
+
+  const selectedNoteBackgrounds = useMemo((): Map<number, string> | null => {
+    if (majorScaleChordRoot === null || majorScaleChordNotes.length === 0) return null
+
+    // Copy the same degree-mapping + band coloring used by `ChordMajorScaleRow`
+    const SEMITONE_TO_DEGREE = [0, 1, 1, 2, 2, 3, 4, 4, 4, 5, 6, 6] as const
+    const intervalToDegreeIdx = (interval: number): number => {
+      if (interval >= 0 && interval <= 11) return SEMITONE_TO_DEGREE[interval]!
+      if (interval === 12) return 7
+      const reduced = interval - 12
+      if (reduced >= 0 && reduced <= 11) return 7 + SEMITONE_TO_DEGREE[reduced]!
+      if (interval < 0) {
+        const positive = interval + 12
+        if (positive >= 0 && positive <= 11) return SEMITONE_TO_DEGREE[positive]! - 7
+      }
+      return 0
+    }
+    const degreeToNote = new Map<number, number>()
+    for (const ref of majorScaleChordNotes) {
+      const interval = ref.index - majorScaleChordRoot
+      const degreeIdx = intervalToDegreeIdx(interval)
+      degreeToNote.set(degreeIdx, ref.index)
+    }
+
+    const degrees = [...degreeToNote.keys()]
+    if (degrees.length === 0) return null
+    const band = scaleToneBand(degrees.length)
+
+    const noteToColor = new Map<number, string>()
+    degrees.forEach((deg, i) => {
+      const noteIdx = degreeToNote.get(deg)
+      if (noteIdx === undefined) return
+      noteToColor.set(noteIdx, band[i] ?? band[0]!)
+    })
+    return noteToColor
+  }, [majorScaleChordRoot, majorScaleChordNotes])
+
   const handlePlayNote = useCallback((note: Note) => playNote(note), [])
+
+  const [isSlidingChromatic, setIsSlidingChromatic] = useState(false)
 
   const [sliderRef, sliderInstanceRef] = useKeenSlider({
     slides: {
@@ -62,6 +238,18 @@ export default function VisualizerPanel() {
     },
     defaultAnimation: { duration: 125 },
     initial: notes.findIndex((n) => n.equals(DEFAULT_ROOT_NOTE)) - BASE_SCALE_LEFT_OVERFLOW,
+    dragStarted() {
+      setIsSlidingChromatic(true)
+    },
+    dragEnded() {
+      setIsSlidingChromatic(false)
+    },
+    animationStarted() {
+      setIsSlidingChromatic(true)
+    },
+    animationEnded() {
+      setIsSlidingChromatic(false)
+    },
     slideChanged(s) {
       const rootIndex = s.track.details.abs + BASE_SCALE_LEFT_OVERFLOW
       setRootNote(notes[rootIndex]!)
@@ -104,24 +292,25 @@ export default function VisualizerPanel() {
         />
 
         <HoverLines
-          hoveredIndex={hoveredTriadIndex}
           containerRef={diagramRef}
           modeNotesWithOverflow={modeNotesWithOverflow}
           modeLeftOverflowSize={modeLeftOverflowSize}
-          chordHighlightPairs={chordHighlightPairs}
-          originalChordNotes={voicedOriginal}
-          modifiedChordNotes={voicedModified}
-          slashBassNoteIndex={slashBassNoteIndex}
+          layers={hoverLineLayers}
+          freeze={isSlidingChromatic}
         />
 
-        {/* Chord root's major scale — content appears on chord hover */}
-        <ChordMajorScaleRow chordNotes={fullVoicedModified} chordRootIndex={chordRootIndex} />
+        {/* Chord root's major scale — mouse hover wins when both pinned and hovered */}
+        <ChordMajorScaleRow
+          chordNotes={majorScaleChordNotes}
+          chordRootIndex={majorScaleChordRoot}
+        />
 
         <ChromaticScaleRow
           sliderRef={sliderRef}
           notes={notes}
           modeIntervals={modeIntervals}
-          highlightedBaseIdxs={highlightedBaseIdxs}
+          highlightedBaseIdxs={mergedHighlightedBaseIdxs}
+          highlightedBaseBackgrounds={selectedNoteBackgrounds}
           onPlayNote={handlePlayNote}
           onPrev={handlePrev}
           onNext={handleNext}
@@ -132,7 +321,8 @@ export default function VisualizerPanel() {
           modeNotesWithOverflow={modeNotesWithOverflow}
           modeIntervals={modeIntervals}
           modeLeftOverflowSize={modeLeftOverflowSize}
-          highlightedModeIdxs={highlightedModeIdxs}
+          highlightedModeIdxs={mergedHighlightedModeIdxs}
+          highlightedModeBackgrounds={selectedNoteBackgrounds}
           onPlayNote={handlePlayNote}
         />
 
@@ -148,6 +338,8 @@ export default function VisualizerPanel() {
           onChordHoverChange={handleChordHoverChange}
           arpeggiate={arpeggiate}
           hoveredIndex={hoveredTriadIndex}
+          pinnedChordIndex={pinnedChordIndex}
+          onPinnedChordChange={setPinnedChordIndex}
           captionRight={
             hasAnyExtensionsOrSlash ? (
               <button

--- a/src/components/ui/PopoverTrigger.tsx
+++ b/src/components/ui/PopoverTrigger.tsx
@@ -1,10 +1,11 @@
 export default function PopoverTrigger() {
   return (
     <button
-      className="rounded-full border border-[var(--app-border)] bg-white px-2 py-0.5 text-[10px] font-medium text-black hover:bg-black/[0.08]"
+      type="button"
+      className="inline-flex h-6 min-w-[2.25rem] shrink-0 items-center justify-center rounded-full border border-[var(--app-border)] bg-white px-2 text-[10px] font-medium text-black hover:bg-black/[0.08]"
       aria-label="Extensions"
     >
-      Extensions
+      Ext
     </button>
   )
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { useModeTones } from "./useModeTones"
 export { useChordExtensions } from "./useChordExtensions"
-export { useChordHover } from "./useChordHover"
+export { useChordHover, computeChordHoverLayer } from "./useChordHover"
 export { useContainerMeasure } from "./useContainerMeasure"
 export { useClickOutside } from "./useClickOutside"

--- a/src/hooks/useChordHover.ts
+++ b/src/hooks/useChordHover.ts
@@ -11,6 +11,112 @@ type HoverState = {
   modified: NoteRef[],
 }
 
+export type ChordHoverLayerComputed = {
+  voicedOriginal: NoteRef[],
+  voicedModified: NoteRef[],
+  fullVoicedModified: NoteRef[],
+  slashBassNoteIndex: NoteIndex | null,
+  chordHighlightPairs: ChordHighlightPair[],
+  highlightedModeIdxs: Set<number>,
+  highlightedBaseIdxs: Set<number>,
+  chordRootIndex: NoteIndex | null,
+}
+
+export function computeChordHoverLayer(
+  triadIndex: number | null,
+  original: NoteRef[],
+  modified: NoteRef[],
+  modeNotesWithOverflow: NoteRef[],
+  visibleModeNotes: NoteRef[],
+  slashBasses: (number | null)[],
+  notes: Note[],
+): ChordHoverLayerComputed {
+  const modeIndices = modeNotesWithOverflow.map((r) => r.index)
+  const modeNoteIndices = visibleModeNotes.map((r) => r.index)
+  const modifiedHoverNotes = modified
+
+  if (triadIndex === null || modified.length === 0) {
+    return {
+      voicedOriginal: [],
+      voicedModified: [],
+      fullVoicedModified: [],
+      slashBassNoteIndex: null,
+      chordHighlightPairs: [],
+      highlightedModeIdxs: new Set(),
+      highlightedBaseIdxs: new Set(),
+      chordRootIndex: null,
+    }
+  }
+
+  const slashBass = slashBasses[triadIndex]
+  const slashBassNoteIndex =
+    slashBass === null || slashBass === undefined
+      ? null
+      : getSlashBassNote(modeNoteIndices, triadIndex, slashBass)
+
+  const voiceChord = (chordNotes: NoteRef[]): NoteRef[] => {
+    if (slashBass === null || slashBass === undefined || chordNotes.length === 0) {
+      return chordNotes
+    }
+    const chordIndices = chordNotes.map((r) => r.index)
+    const voicedIndices = buildSlashChordVoicing(
+      chordIndices,
+      modeNoteIndices,
+      triadIndex,
+      slashBass,
+    ).slice(1)
+    return toNoteRefs(voicedIndices, notes)
+  }
+
+  const voicedOriginal = voiceChord(original)
+  const voicedModified = voiceChord(modifiedHoverNotes)
+
+  const fullVoicedModified: NoteRef[] =
+    slashBassNoteIndex === null
+      ? voicedModified
+      : [toNoteRef(slashBassNoteIndex, notes), ...voicedModified]
+
+  const originalSet = new Set(voicedOriginal.map((r) => r.index))
+  const notesToHighlight =
+    originalSet.size > 0 ? voicedModified.filter((r) => originalSet.has(r.index)) : voicedModified
+
+  const chordHighlightPairs: ChordHighlightPair[] = notesToHighlight
+    .map((ref) => {
+      const modeIdx = modeIndices.indexOf(ref.index)
+      if (modeIdx < 0) return null
+      return { modeIdx, baseIdx: ref.index }
+    })
+    .filter((p): p is ChordHighlightPair => p !== null)
+
+  const highlightedModeIdxs = new Set(chordHighlightPairs.map((p) => p.modeIdx))
+
+  const highlightedBaseIdxs = new Set(
+    voicedModified
+      .map((r) => r.index)
+      .filter((idx): idx is NoteIndex => idx >= 0 && idx < notes.length),
+  )
+  if (
+    slashBassNoteIndex !== null &&
+    slashBassNoteIndex >= 0 &&
+    slashBassNoteIndex < notes.length
+  ) {
+    highlightedBaseIdxs.add(slashBassNoteIndex)
+  }
+
+  const chordRootIndex = modifiedHoverNotes.length > 0 ? modifiedHoverNotes[0]!.index : null
+
+  return {
+    voicedOriginal,
+    voicedModified,
+    fullVoicedModified,
+    slashBassNoteIndex,
+    chordHighlightPairs,
+    highlightedModeIdxs,
+    highlightedBaseIdxs,
+    chordRootIndex,
+  }
+}
+
 export function useChordHover(
   modeNotesWithOverflow: NoteRef[],
   visibleModeNotes: NoteRef[],
@@ -23,18 +129,7 @@ export function useChordHover(
     modified: [],
   })
 
-  const modeIndices = useMemo(
-    () => modeNotesWithOverflow.map((r) => r.index),
-    [modeNotesWithOverflow],
-  )
-
-  const modeNoteIndices = useMemo(
-    () => visibleModeNotes.map((r) => r.index),
-    [visibleModeNotes],
-  )
-
   const hoveredTriadIndex = hoverState.index
-  const modifiedHoverNotes = hoverState.modified
 
   const setHoveredTriadIndex = useCallback((idx: number | null) => {
     if (idx === null) {
@@ -60,92 +155,30 @@ export function useChordHover(
     }
   }, [])
 
-  const slashBassNoteIndex = useMemo<NoteIndex | null>(() => {
-    if (hoveredTriadIndex === null) return null
-    const slashBass = slashBasses[hoveredTriadIndex]
-    if (slashBass === null || slashBass === undefined) return null
-    return getSlashBassNote(modeNoteIndices, hoveredTriadIndex, slashBass)
-  }, [hoveredTriadIndex, slashBasses, modeNoteIndices])
-
-  const hoveredSlashBass = useMemo(() => {
-    if (hoveredTriadIndex === null) return null
-    return slashBasses[hoveredTriadIndex] ?? null
-  }, [hoveredTriadIndex, slashBasses])
-
-  const voiceForSlash = useCallback(
-    (chordNotes: NoteRef[]): NoteRef[] => {
-      if (hoveredSlashBass === null || hoveredTriadIndex === null || chordNotes.length === 0)
-        return chordNotes
-      const chordIndices = chordNotes.map((r) => r.index)
-      const voicedIndices = buildSlashChordVoicing(chordIndices, modeNoteIndices, hoveredTriadIndex, hoveredSlashBass).slice(1)
-      return toNoteRefs(voicedIndices, notes)
-    },
-    [hoveredSlashBass, hoveredTriadIndex, modeNoteIndices, notes],
+  const layer = useMemo(
+    () =>
+      computeChordHoverLayer(
+        hoverState.index,
+        hoverState.original,
+        hoverState.modified,
+        modeNotesWithOverflow,
+        visibleModeNotes,
+        slashBasses,
+        notes,
+      ),
+    [hoverState, modeNotesWithOverflow, visibleModeNotes, slashBasses, notes],
   )
-
-  const voicedOriginal = useMemo(
-    () => voiceForSlash(hoverState.original),
-    [hoverState.original, voiceForSlash],
-  )
-  const voicedModified = useMemo(
-    () => voiceForSlash(modifiedHoverNotes),
-    [modifiedHoverNotes, voiceForSlash],
-  )
-
-  const fullVoicedModified = useMemo<NoteRef[]>(() => {
-    if (slashBassNoteIndex === null) return voicedModified
-    return [toNoteRef(slashBassNoteIndex, notes), ...voicedModified]
-  }, [voicedModified, slashBassNoteIndex, notes])
-
-  const chordHighlightPairs = useMemo<ChordHighlightPair[]>(() => {
-    if (!voicedModified.length) return []
-
-    const originalSet = new Set(voicedOriginal.map((r) => r.index))
-    const notesToHighlight =
-      originalSet.size > 0 ? voicedModified.filter((r) => originalSet.has(r.index)) : voicedModified
-
-    return notesToHighlight
-      .map((ref) => {
-        const modeIdx = modeIndices.indexOf(ref.index)
-        if (modeIdx < 0) return null
-        return { modeIdx, baseIdx: ref.index }
-      })
-      .filter((p): p is ChordHighlightPair => p !== null)
-  }, [voicedModified, modeIndices, voicedOriginal])
-
-  const highlightedModeIdxs = useMemo(
-    () => new Set(chordHighlightPairs.map((p) => p.modeIdx)),
-    [chordHighlightPairs],
-  )
-
-  const highlightedBaseIdxs = useMemo(() => {
-    const idxs = new Set(
-      voicedModified
-        .map((r) => r.index)
-        .filter((idx): idx is NoteIndex => idx >= 0 && idx < notes.length),
-    )
-    if (
-      slashBassNoteIndex !== null &&
-      slashBassNoteIndex >= 0 &&
-      slashBassNoteIndex < notes.length
-    ) {
-      idxs.add(slashBassNoteIndex)
-    }
-    return idxs
-  }, [voicedModified, slashBassNoteIndex, notes.length])
-
-  const chordRootIndex = modifiedHoverNotes.length > 0 ? modifiedHoverNotes[0]!.index : null
 
   return {
     hoveredTriadIndex,
-    fullVoicedModified,
-    chordRootIndex,
-    voicedOriginal,
-    voicedModified,
-    slashBassNoteIndex,
-    chordHighlightPairs,
-    highlightedModeIdxs,
-    highlightedBaseIdxs,
+    fullVoicedModified: layer.fullVoicedModified,
+    chordRootIndex: layer.chordRootIndex,
+    voicedOriginal: layer.voicedOriginal,
+    voicedModified: layer.voicedModified,
+    slashBassNoteIndex: layer.slashBassNoteIndex,
+    chordHighlightPairs: layer.chordHighlightPairs,
+    highlightedModeIdxs: layer.highlightedModeIdxs,
+    highlightedBaseIdxs: layer.highlightedBaseIdxs,
     setHoveredTriadIndex,
     handleChordHoverChange,
   }

--- a/src/hooks/useModeTones.ts
+++ b/src/hooks/useModeTones.ts
@@ -37,14 +37,24 @@ export function useModeTones(
   )
 
   const modeConnections = useMemo<CellLink[]>(
-    () =>
-      modeIntervals.map((interval, idx) => ({
-        fromRow: "chromatic-row",
-        fromIdx: interval,
-        toRow: "mode-row",
-        toIdx: modeLeftOverflowSize + idx,
-      })),
-    [modeIntervals, modeLeftOverflowSize],
+    () => {
+      if (modeIndicesWithOverflow.length === 0) return []
+      const rootAbsIdx = modeIndicesWithOverflow[modeLeftOverflowSize]
+      if (rootAbsIdx === undefined) return []
+      return modeIndicesWithOverflow
+        .map((absNoteIdx, toIdx) => {
+          if (absNoteIdx < 0 || absNoteIdx >= notes.length) return null
+          const chromaticIdx = absNoteIdx - rootAbsIdx
+          return {
+            fromRow: "chromatic-row" as const,
+            fromIdx: chromaticIdx,
+            toRow: "mode-row" as const,
+            toIdx,
+          }
+        })
+        .filter((c): c is CellLink => c !== null)
+    },
+    [modeIndicesWithOverflow, modeLeftOverflowSize, notes.length],
   )
 
   return {

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -19,11 +19,11 @@ export function shade(color: RGBColor, t: number): RGBColor {
  * with subtle hue variation. `spread` controls how wide the band is (0.06 = ±3%).
  * Each color is tinted to pastel. Returns `RGBColor[]` — call `.formatHex()` at DOM boundaries.
  */
-export function hueBand(center: number, count: number, spread: number, tintAmt: number): RGBColor[] {
-  if (count <= 1) return [tint(rgb(interpolateRainbow(center)), tintAmt)]
+export function hueBand(center: number, count: number, spread: number): RGBColor[] {
+  if (count <= 1) return [rgb(interpolateRainbow(center))]
   const start = center - spread / 2
   return Array.from({ length: count }, (_, i) => {
     const t = start + (spread * i) / (count - 1)
-    return tint(rgb(interpolateRainbow(t)), tintAmt)
+    return rgb(interpolateRainbow(t))
   })
 }

--- a/src/lib/music/scale.ts
+++ b/src/lib/music/scale.ts
@@ -3,7 +3,7 @@ import { Note } from "../../models"
 import { CHROMATIC_SCALE } from "../notes"
 import { OCTAVE } from "./modes"
 
-export const BASE_SCALE_LEFT_OVERFLOW = 5
+export const BASE_SCALE_LEFT_OVERFLOW = 8
 export const BASE_SCALE_WITH_OVERFLOW_SIZE =
   CHROMATIC_SCALE.length + 2 * BASE_SCALE_LEFT_OVERFLOW
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,10 +1,13 @@
-import { schemeSet3, interpolateRainbow, interpolateWarm } from "d3-scale-chromatic"
+import { schemeSet3, interpolateRainbow } from "d3-scale-chromatic"
 import { quantize } from "d3-interpolate"
 import { scaleOrdinal } from "d3-scale"
 import { rgb } from "d3-color"
-import { tint, shade } from "./colors"
+import { tint, shade, hueBand } from "./colors"
 
-const RAINBOW_UI = 0.85 // blue
+const RAINBOW_ROOT = 0.68 // teal green
+const RAINBOW_SCALE = 0.40 // yellow ochre
+const RAINBOW_UI = 0.85 // blue (UI buttons / focus rings)
+const RAINBOW_RESPELLING = 0.70 // teal
 
 /** Slots for diatonic degree cells (7 degrees + octave / wrap). Observable-style: `scaleOrdinal(quantize(interpolateRainbow, n))`. */
 const DEGREE_SLOT_COUNT = 8
@@ -41,14 +44,21 @@ export const BLACK = "black"
  * Use `colors.*` in inline styles, SVG attributes, and component props.
  * Use `var(--app-tokenName)` in Tailwind classes (e.g. `bg-[var(--app-primary)]`).
  *
- * Note: UI tokens below use `tint` / `shade` in `src/lib/colors.ts`.
+ * Note: UI / scale / root tokens below use `tint` / `shade` in `src/lib/colors.ts`.
  * Only diatonic degree fills (`DEGREE_COLORS`, `degreeColor`) use rainbow + `RAINBOW_DEGREE_FILL_OPACITY` only.
  */
 export const colors = {
   primary: shade(rgb(interpolateRainbow(RAINBOW_UI)), 0.20).formatHex(),
   primaryHover: shade(rgb(interpolateRainbow(RAINBOW_UI)), 0.35).formatHex(),
   primaryFill: tint(rgb(interpolateRainbow(RAINBOW_UI)), 0.75).formatHex(),
+  scaleFill: tint(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.45).formatHex(),
+  scaleBorder: shade(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.25).formatHex(),
+  scaleText: shade(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.35).formatHex(),
+  rootFill: tint(rgb(interpolateRainbow(RAINBOW_ROOT)), 0.45).formatHex(),
+  rootBorder: shade(rgb(interpolateRainbow(RAINBOW_ROOT)), 0.25).formatHex(),
   grayText: shade(LGRAY, 0.55).formatHex(),
+  respelling: shade(rgb(interpolateRainbow(RAINBOW_RESPELLING)), 0.40).formatHex(),
+  rowBg: tint(LGRAY, 0.55).formatHex(),
   border: tint(LGRAY, 0.30).formatHex(),
   muted: LGRAY.formatHex(),
   mutedDark: shade(LGRAY, 0.15).formatHex(),
@@ -67,12 +77,9 @@ export function degreeColor(index: number): string {
   return DEGREE_COLORS[index % DEGREE_COLORS.length]!
 }
 
-/** Generate `count` scale-tone background hex colors sampled from the warm spectrum. */
+/** Generate `count` scale-tone background hex colors as a subtle hue-varied band. */
 export function scaleToneBand(count: number): string[] {
-  if (count <= 1) return [rgb(interpolateWarm(0.5)).formatHex()]
-  return Array.from({ length: count }, (_, i) =>
-    rgb(interpolateWarm(i / (count - 1))).formatHex()
-  )
+  return hueBand(RAINBOW_SCALE, count, 0.10).map((c) => tint(c, 0.45).formatHex())
 }
 
 /** Register `--app-*` CSS custom properties on `:root`. Call once at startup before React renders. */

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,53 +1,48 @@
-import { schemeSet3, interpolateRainbow } from "d3-scale-chromatic"
+import { schemeSet3, interpolateRainbow, interpolateWarm } from "d3-scale-chromatic"
 import { rgb } from "d3-color"
 import type { RGBColor } from "d3-color"
-import { tint, shade, hueBand } from "./colors"
+import { tint, shade } from "./colors"
 
-const RAINBOW_ROOT = 0.68 // teal green
-const RAINBOW_SCALE = 0.40 // yellow ochre
-const RAINBOW_UI = 0.85 // blue (UI buttons / focus rings)
-const RAINBOW_RESPELLING = 0.70 // teal
+const RAINBOW_UI = 0.85 // blue
 
 const LGRAY = rgb(schemeSet3[8]!) // #d9d9d9
 
-/**
- * Central color tokens — derived from `interpolateRainbow`.
- *
- * Use `colors.*` in inline styles, SVG attributes, and component props.
- * Use `var(--app-tokenName)` in Tailwind classes (e.g. `bg-[var(--app-primary)]`).
- */
+export const neonHoverCellOutline = {
+  boxShadow:
+    "inset 0 0 0 1px black, 0 0 0 1px black",
+} as const
+
+export const BLACK = "black"
+
 export const colors = {
   primary: shade(rgb(interpolateRainbow(RAINBOW_UI)), 0.20).formatHex(),
   primaryHover: shade(rgb(interpolateRainbow(RAINBOW_UI)), 0.35).formatHex(),
   primaryFill: tint(rgb(interpolateRainbow(RAINBOW_UI)), 0.75).formatHex(),
-  scaleFill: tint(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.45).formatHex(),
-  scaleBorder: shade(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.25).formatHex(),
-  scaleText: shade(rgb(interpolateRainbow(RAINBOW_SCALE)), 0.35).formatHex(),
-  rootFill: tint(rgb(interpolateRainbow(RAINBOW_ROOT)), 0.45).formatHex(),
-  rootBorder: shade(rgb(interpolateRainbow(RAINBOW_ROOT)), 0.25).formatHex(),
   grayText: shade(LGRAY, 0.55).formatHex(),
-  respelling: shade(rgb(interpolateRainbow(RAINBOW_RESPELLING)), 0.40).formatHex(),
-  rowBg: tint(LGRAY, 0.55).formatHex(),
   border: tint(LGRAY, 0.30).formatHex(),
   muted: LGRAY.formatHex(),
+  mutedDark: shade(LGRAY, 0.15).formatHex(),
 } as const
 
 /** Tailwind text color class for de-emphasized notes (non-chord-tones, struck-through naturals, arrows). */
 export const MUTED_TEXT = "text-gray-500"
 
-/** 8 rainbow colors (7 degrees + octave), tinted to pastel for cell backgrounds. */
+/** 8 warm-spectrum colors (7 degrees + octave) for cell backgrounds. */
 export const DEGREE_COLORS: RGBColor[] = Array.from({ length: 8 }, (_, i) =>
-  tint(rgb(interpolateRainbow(i / 8)), 0.45)
+  rgb(interpolateWarm(i / 7))
 )
 
-/** Return the pastel background hex color for a given scale degree index. */
+/** Return the background hex color for a given scale degree index. */
 export function degreeColor(index: number): string {
   return DEGREE_COLORS[index % DEGREE_COLORS.length]!.formatHex()
 }
 
-/** Generate `count` scale-tone background hex colors as a subtle hue-varied band. */
+/** Generate `count` scale-tone background hex colors sampled from the warm spectrum. */
 export function scaleToneBand(count: number): string[] {
-  return hueBand(RAINBOW_SCALE, count, 0.10, 0.45).map((c) => c.formatHex())
+  if (count <= 1) return [rgb(interpolateWarm(0.5)).formatHex()]
+  return Array.from({ length: count }, (_, i) =>
+    rgb(interpolateWarm(i / (count - 1))).formatHex()
+  )
 }
 
 /** Register `--app-*` CSS custom properties on `:root`. Call once at startup before React renders. */


### PR DESCRIPTION
## Summary
- **Pinned chords**: click pin icon on any diatonic chord to lock its hover state (lines, highlights, major scale row). Clears on mode change.
- **Static FixedLines**: connections draw from the immovable `chromatic-row` cells instead of the sliding `base-row`, so lines stay fixed during keen-slider animation. Overflow positions extrapolated mathematically — 18 lines (full mode row) instead of 7.
- **Warm color scheme**: switched from `interpolateRainbow` to `interpolateWarm` (d3) for degree cells and chord tone highlights. Removed tinting from non-monochrome colors.
- **UI polish**: border-box sizing, boxShadow grid outlines, thicker lines (strokeWidth 2), darkgray static lines, thick borders on active Root Major Scale cells, key hint tooltip debounce fix, restored missing CSS var colors.
- **HoverLines multi-layer**: refactored to render pinned + hovered chord lines simultaneously with freeze during slider animation.

## Test plan
- [x] All 92 unit tests pass
- [ ] Verify pinned chord persists across hover interactions
- [ ] Verify lines stay static when sliding chromatic row
- [ ] Verify arpeggiate toggle is visible when enabled
- [ ] Verify key click tooltip appears with dark background
- [ ] Visual check of warm color scheme across modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)